### PR TITLE
Object detection optimization

### DIFF
--- a/soldierFSM/Functions/vehicles/fn_availableVehicles.sqf
+++ b/soldierFSM/Functions/vehicles/fn_availableVehicles.sqf
@@ -1,7 +1,7 @@
 params["_pos", "_radius"];
 
 private _availableVehicles = 
-(_pos nearObjects ["car", _radius])
+(_pos nearEntities ["car", _radius])
 select {[_x] call SFSM_fnc_vehicleAvailable;};
 
 

--- a/soldierFSM/Functions/vehicles/fn_reinforceVehicles.sqf
+++ b/soldierFSM/Functions/vehicles/fn_reinforceVehicles.sqf
@@ -8,7 +8,7 @@ private _vehicleFilter = {
 	(_type in SFSM_hijackVehicleTypes
 	&&{[_x] call SFSM_fnc_vehicleNeedsCrew})
 };
-private _vehicles = (_pos nearObjects ["car", _radius]) select _vehicleFilter;
+private _vehicles = (_pos nearEntities ["car", _radius]) select _vehicleFilter;
 
 {
 	private _nearestVehicle = [_x, _vehicles] call Tcore_fnc_nearestPos;

--- a/soldierFSM/functions/battlefield/fn_AddWeaponsToBattlefield.sqf
+++ b/soldierFSM/functions/battlefield/fn_AddWeaponsToBattlefield.sqf
@@ -5,10 +5,7 @@ private _battlefield = SFSM_Battles get _battleKey;
 
 if(isNil "_battlefield")exitWith{};
 
-private _unitPos        = getPos _man;
-private _droppedWeapons = _unitPos nearObjects ["WeaponHolderSimulated", 5];
-private _placedWeapons  = _unitPos nearObjects ["WeaponHolder", 5];
-_droppedWeapons append _placedWeapons;
+private _droppedWeapons = nearestObjects [_man, ["WeaponHolder", "WeaponHolderSimulated"], 5];
 
 private _weaponCount    = count _droppedWeapons;
 

--- a/soldierFSM/functions/battlefield/fn_InitBattlefield.sqf
+++ b/soldierFSM/functions/battlefield/fn_InitBattlefield.sqf
@@ -59,9 +59,7 @@ private _areaName        = _battlefield get "name";
 private _deadMen         = [_centerPos, _radius] call Tcore_fnc_deadMenInArea;
 
 
-private _weapons         = _centerPos nearObjects ["WeaponHolderSimulated", _radius];
-private _placedWeapons   = _centerPos nearObjects ["WeaponHolder", _radius];
-_weapons append _placedWeapons;
+private _weapons = nearestObjects [_centerPos, ["WeaponHolder", "WeaponHolderSimulated"], _radius];
 
 //store the variables that are not included in the "battlefield"-hashmap itself.
 [

--- a/soldierFSM/functions/battlefield/fn_updateBattlefield.sqf
+++ b/soldierFSM/functions/battlefield/fn_updateBattlefield.sqf
@@ -41,9 +41,7 @@ private _units       = [_clustersData]       call Tcore_fnc_clusterUnits select 
 private _vehicles    = [_clustersData]       call Tcore_fnc_clusterVehicles;
 private _deadMen     = missionNamespace getVariable (_battleField get "deadMen");
 
-private _weapons         = _centerPos nearObjects ["WeaponHolderSimulated", _radius];
-private _placedWeapons   = _centerPos nearObjects ["WeaponHolder", _radius];
-_weapons append _placedWeapons;
+private _weapons = nearestObjects [_centerPos, ["WeaponHolder", "WeaponHolderSimulated"], _radius];
 
 //see comments at Fn_initBattlefield.sqf
 [

--- a/soldierFSM/functions/core/fn_coverPosStance.sqf
+++ b/soldierFSM/functions/core/fn_coverPosStance.sqf
@@ -10,8 +10,8 @@ private _crouchPos      = AGLToASL [_coverPos # 0, _coverPos # 1, 1.1];
 private _pronePos       = AGLToASL [_coverPos # 0, _coverPos # 1, 0.4];
 private _coverPositions = [_standPos, _crouchPos, _pronePos];
 private _stances 		= ["ERECT", "CROUCH", "PRONE"];
-private _ignoreObj      = (nearestObjects [_coverPos, ["man"], 5]) # 0;
-private _ignoreObj2     = (nearestObjects [_coverPos, ["man"], 5]) # 0;
+private _ignoreObj      = (nearestObjects [_coverPos, ["CAManBase"], 5]) # 0;
+private _ignoreObj2     = (nearestObjects [_coverPos, ["CAManBase"], 5]) # 0;
 
 if(isNil "_ignoreObj")then {_ignoreObj = objNull};
 if(isNil "_ignoreObj2")then{_ignoreObj2 = objNull};


### PR DESCRIPTION
Changed: ``nearObjects`` simplified to ``nearestObjects`` where possible

Changed: ``nearObjects`` simplified to ``nearEntities`` where possible

Fixed: a bug in ``fn_coverPosStance`` where rabbits etc were accidentally evaluated